### PR TITLE
Switch codepen for jsdelivr

### DIFF
--- a/Example1/free_particle.py
+++ b/Example1/free_particle.py
@@ -12,7 +12,7 @@ import dash_defer_js_import as dji
 
 filepath = os.path.split(os.path.realpath(__file__))[0]
 
-external_stylesheets = ['https://codepen.io/yueyericardo/pen/OJyLrKR.css',
+external_stylesheets = ['https://cdn.jsdelivr.net/gh/yueyericardo/simuc@master/apps/dash/resources/dash.css',
                         'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/monokai-sublime.min.css']
 
 
@@ -105,7 +105,7 @@ def getfig2(k=4, dk=2, xmax=5):
     return fig
 
 ###### important for latex ######
-axis_latex_script = dji.Import(src="https://codepen.io/yueyericardo/pen/pojyvgZ.js")
+axis_latex_script = dji.Import(src="https://cdn.jsdelivr.net/gh/yueyericardo/simuc@master/apps/dash/resources/redraw.js")
 mathjax_script = dji.Import(src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS-MML_SVG")
 
 # fig2


### PR DESCRIPTION
I was interested in giving this a try because I was hoping it might help to solve https://github.com/plotly/plotly.js/issues/5374 (LaTeX + Plotly + Firefox is broken). But now I think I was confused, because the current issues seem to be unrelated to Dash. This is a problem in Plotly, not in your code.

Here's what the broken LaTeX looks like for me in Firefox. (In Chrome it seems to work.)

![image](https://user-images.githubusercontent.com/15216687/120111462-587dbd00-c172-11eb-9c0f-e1a14446d2c0.png)

Note the error in the Javascript console. I'm not sure where the `toggle_code` element is supposed to come from.